### PR TITLE
Cross_connect_server: Add a better warning when no api key

### DIFF
--- a/cross_connect_client/models/cross_connect_server.py
+++ b/cross_connect_client/models/cross_connect_server.py
@@ -88,6 +88,10 @@ class CrossConnectServer(models.Model):
     def _request(self, method, url, headers=None, data=None):
         headers = headers or {}
         headers["api-key"] = self.api_key
+        if not self.api_key:
+            raise UserError(
+                self.env._("Missing api key in Cross Connect Servers to continue")
+            )
         response = requests.request(
             method,
             self._absolute_url_for(url),


### PR DESCRIPTION
Before

<img width="1065" height="217" alt="2025-10-15_15-53" src="https://github.com/user-attachments/assets/a3e9ccc9-413b-4ad5-a166-2c5622b75376" />


After
<img width="531" height="236" alt="2025-10-15_15-52" src="https://github.com/user-attachments/assets/5209cc47-f89c-4adc-88b6-54954e17216c" />

cc @paradoxxxzero @florian-dacosta 


Event: when you get a db without env key